### PR TITLE
adds search bar as last element in top horizontal nav bar

### DIFF
--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -92,6 +92,15 @@
             </svg>
           </a>
         </div>
+        
+{{#if env.SITE_SEARCH_PROVIDER}}
+       <div class="navbar-item search hide-for-print">
+        <div id="search-field" class="field">
+          <input id="search-input" type="text" placeholder="Search the docs"{{#if page.home}} autofocus{{/if}}>
+        </div>
+       </div>
+{{/if}}
+
       </div>
     </div>
   </nav>


### PR DESCRIPTION
This is the UI needed changes to enable the search bar. 
See kaskada-ai/kaskada#249

It should appear as the last element on the top nav bar

![image](https://user-images.githubusercontent.com/284529/233501590-d3643764-1f8e-4df5-8cc8-f4487386c360.png)


Steps to complete the addition of the search bar 

1. Commit and release a new UI bundle 
    * this is safe since the search bar is wrapped in an if statement that checks an environment variable that is only set once we enable the search extension 
2. Make the changes to `docs-site` repo commit and publish
    * See https://github.com/kaskada-ai/docs-site/pull/12
 